### PR TITLE
CG-34 CI環境の修正

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -8,8 +8,6 @@ name: "Ruby on Rails CI"
 on:
   push:
     branches: [ "main", "develop", "feature/**" ]
-  pull_request:
-    branches: [ "feature/**" ]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## JIRAへのリンク
CG-34 CI環境の修正

## 概要
設定ファイルの誤りにより、featureブランチの名前によってはCIが動作しない  
`feature/*` ではなく `feature/**` で設定する必要があった  
 
参考: Github Actions チートシート
https://zenn.dev/masaaania/articles/c930f2f755a577

## 実装内容
- [x] featureブランチでpushした際にCIが動作するように修正

## テスト  
- [x] featureブランチでpushした際にCIが走ることを目視で確認  
https://github.com/huro3h/study_records/actions/runs/3862103689
  
## 備考
