### PR TITLE
CG-25 Heroku上でDBに接続するための設定を追加する

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,13 +82,11 @@ test:
 # URL environment variable explicitly:
 #
 #   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
+#     url: <#%= ENV["MY_APP_DATABASE_URL"] %>
 #
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #
 production:
   <<: *default
-  database: study_records_production
-  username: study_records
-  password: <%= ENV["STUDY_RECORDS_DATABASE_PASSWORD"] %>
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
## JIRAへのリンク
CG-25 Heroku上でDBに接続するための設定を追加する

## 概要
Heroku上のDBにアクセスする用の接続情報がHeroku側の環境変数の形で用意されているので  
そこを参照するように `database.yml` を修正しました。  

( [CG\-16 自動テスト環境構築](https://github.com/huro3h/study_records/pull/8) 同様このPRも設定方法を共有する目的です。  
内容だけざっと確認いただけたらマージいただいて大丈夫です :pray:)

設定の際参考にした情報   
Configuring Rails Applications — Ruby on Rails Guides  
https://edgeguides.rubyonrails.org/configuring.html#configuring-a-database   

## 実装内容
- [x] Heroku上のpostgresに接続するようにdatabase.ymlを修正

## テスト  
- [x] 特になし。(本番にデプロイしてみないと正直わからない部分がありますが、接続エラーが起きた場合対応します)

## 備考
Heroku側の環境変数を手元から参照した際、`DATABASE_URL` が定義されていましたので、　　
ここに繋ぎに行く設定になります    
  
<img width="467" alt="ss-2" src="https://user-images.githubusercontent.com/16791696/211196013-08766422-e179-43ad-a2b0-910f0c4ac392.png">
  

