### PR TITLE
ログインフォームを追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,23 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:session][:email])
+    if user&.authenticate(params[:session][:password])
+      redirect_to tops_url
+    else
+      flash.now[:danger] = 'ユーザーが見つかりません'
+      render 'new', status: :unprocessable_entity
+    end
+
+  end
+
+  private
+    def user_params
+        # parameterとして許可する属性定義
+        params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    end
+
+
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,21 @@
+<% provide(:title, "Log in") %>
+<h1>ログイン</h1>
+<% flash.each do |message_type, message| %>
+    <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: login_path, scope: :session, local: true) do |f| %>
+      
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+      
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+      
+      <br/>
+      <%= f.submit "ログイン", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,3 +2,6 @@
 <%=link_to(new_user_path) do %>
  <button class="btn btn-secondary btn-lg" >ユーザー登録</button>
 <%end%>
+<%=link_to(login_path) do %>
+ <button class="btn btn-secondary btn-lg" >ログインページ</button>
+<%end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
-
+  
   root 'static_pages#home'
   resources :tops, only: :index
   resources :users
   resources :subjects, only: [:index, :new, :create, :show]
   resources :study_records
+
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
 end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :request do
+    describe 'GET /login' do
+      before do
+        get login_path
+      end
+
+      it 'ステータス200が返ること' do
+        expect(response.status).to eq 200
+      end
+
+      it 'Emailとパスワード入力画面が表示されること' do
+        expect(response.body).to include 'Email'
+        expect(response.body).to include 'Password'
+      end
+  end
+
+  describe "POST #create" do
+    context "正常にログインができた時" do
+      
+      before do
+        @user = create(:user, name: 'test', email: "test@example.com", password: '123456')
+        post login_path params: {
+          session: { email: "test@example.com", password: '123456' }
+        }
+      end
+      
+      it "ステータス302が返ること" do
+        expect(response.status).to eq 302
+      end
+
+      it 'TOPページにリダイレクトすること' do
+        expect(response).to redirect_to('/tops')
+      end
+
+    end
+  end
+
+  describe "ログインに失敗した場合" do
+    context "ユーザーが見つからない場合" do
+      it "ステータス422が返ること" do
+        post login_path params: {
+          session: { email: "test@example.com", password: '123456' }
+        }
+        expect(response.status).to eq 422
+      end
+    end
+  end
+  
+
+end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'root_path', type: :system, js: true do
   describe 'StudyRecords Topページ' do
-    it 'トップページにサービス名とユーザ登録ボタンが表示されていること' do
+    it 'トップページにサービス名とユーザ登録ボタンとログインページボタンが表示されていること' do
       visit root_path
       expect(page).to have_content 'StudyRecords Topページ'
       expect(page).to have_button 'ユーザー登録'
+      expect(page).to have_button 'ログインページ'
     end
   end
 end


### PR DESCRIPTION
## JIRAへのリンク
CG-12 (ログイン機能)

## 概要
ログイン機能を追加しました。

## 実装内容
- [x] sessionコントローラーの追加
- [x] `/login` ページ追加
- [x] `static_pages/new`にログインページボタンがあることを確認するテスト追加
- [x] 以下のテストを新規作成

## テスト  
- [x] ユーザーが見つかれば`tops`ページに遷移することを確認
- [x] ユーザーが見つからなければ「ユーザーが見つかりませんの」 メッセージを表示することを確認

## 備考
まだsession機能がないので単純にユーザーの存在を確認できるのみです。
CG-24でログアウト(session機能)を追加します。