### PR TITLE
CG-42 ユーザの学習記録をユーザトップページに表示する

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,4 +1,17 @@
 class TopsController < ApplicationController
   def index
+    set_user
+    set_study_records
+  end
+
+  private
+
+  def set_user
+    # session実装後に切り替えます
+    @user = User.first # User.find(params[:user_id]) # current_user
+  end
+
+  def set_study_records
+    @study_records = @user.study_records.preload(:subject).order(study_date: :desc).order(id: :desc)
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,19 +1,14 @@
 class TopsController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
-  
+  before_action :logged_in_user
+
   def index
-    set_user
     set_study_records
   end
 
   private
 
-  def set_user
-    # session実装後に切り替えます
-    @user = User.first # User.find(params[:user_id]) # current_user
-  end
-
   def set_study_records
-    @study_records = @user.study_records.preload(:subject).order(study_date: :desc).order(id: :desc)
+    user = current_user
+    @study_records = user.study_records.preload(:subject).order(study_date: :desc).order(id: :desc)
   end
 end

--- a/app/models/study_record.rb
+++ b/app/models/study_record.rb
@@ -19,6 +19,5 @@ class StudyRecord < ApplicationRecord
   belongs_to :user
   belongs_to :subject
 
-  validates :study_date, presence: true, comparison: { less_than_or_equal_to: Time.now }
   validates :study_time, presence: true, numericality: {only_integer: true, greater_than: 0}
 end

--- a/app/models/study_record.rb
+++ b/app/models/study_record.rb
@@ -19,5 +19,6 @@ class StudyRecord < ApplicationRecord
   belongs_to :user
   belongs_to :subject
 
+  validates :study_date, presence: true
   validates :study_time, presence: true, numericality: {only_integer: true, greater_than: 0}
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,12 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container">
-    <%= link_to ApplicationHelper::APPLICATION_NAME, root_path, class: "navbar-brand" %>
+    <%= link_to ApplicationHelper::APPLICATION_NAME, tops_path, class: "navbar-brand" %>
     <div class="collapse navbar-collapse">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
       <% if logged_in? %>
         <li class="nav-item">
           <%= link_to 'Home', tops_path, class: 'nav-link' %>
         </li>
-<!--        <li class="nav-item"><a class="nav-link" href="#">Link</a></li>-->
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             Subjects

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -39,13 +39,12 @@
         </tr>
         </thead>
         <tbody>
-        <% subjects_names = Subject.all.pluck(:name) %>
-        <% (3..12).to_a.sample.times do |index| %>
+        <% @study_records.each.with_index(1) do |study_record, index| %>
           <tr>
-            <th scope="row"><%= index +1 %></th>
-            <td><%= Time.current.ago(index.days).strftime("%F") %></td>
-            <td><%= subjects_names.sample %></td>
-            <td><%= (45..180).to_a.sample %></td>
+            <th scope="row"><%= index %></th>
+            <td><%= study_record.study_date.strftime("%F") %></td>
+            <td><%= study_record.subject.name%></td>
+            <td><%= study_record.study_time %></td>
           </tr>
         <% end %>
         </tbody>

--- a/spec/factories/study_record.rb
+++ b/spec/factories/study_record.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :study_record do
+    association :user, factory: :user
+    association :subject, factory: :subject
+    study_date { Time.current }
+    study_time { Faker::Number.between(from: 1, to: 300) }
+  end
+end

--- a/spec/factories/study_records.rb
+++ b/spec/factories/study_records.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :study_record do
-  end
-end

--- a/spec/factories/subject.rb
+++ b/spec/factories/subject.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
-    factory :subject do
-    end
+  factory :subject do
+    sequence(:name) { |n| "情報アーキテクチャ特論#{n}" }
   end
+end

--- a/spec/system/tops_spec.rb
+++ b/spec/system/tops_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe 'tops_path', type: :system, js: true do
   end
 
   describe 'ユーザの学習記録' do
-    let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') } # 表示される教科名
+    let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') } # 画面に表示される教科名のデータ
 
-    # ログインするユーザとTopページに表示される学習記録
-    let!(:user) { create(:user, name: 'テスト太郎') } # ログインするユーザ
+    # ログインするユーザとTopページに表示される学習記録のテスト用データを作成
+    let!(:user) { create(:user, name: 'テスト太郎') } # ログインするユーザのデータ
     let!(:study_record) {
       create(:study_record, user: user, subject: subject, study_date: Time.new(2023, 1, 16), study_time: 120)
     }
 
-    # 他ユーザの学習記録。ログインしているユーザ以外の学習記録は、ユーザTopページに表示されないことを確認する為
+    # 他ユーザの学習記録。ログインしているユーザ以外の学習記録は、ユーザTopページに表示されないことを確認する為にデータを作っています
     let!(:another_user) { create(:user, name: '他人太郎') }
     let!(:another_study_record) {
       create(:study_record, user: another_user, subject: subject, study_date: Time.new(2023, 1, 11), study_time: 1000)

--- a/spec/system/tops_spec.rb
+++ b/spec/system/tops_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe 'tops_path', type: :system, js: true do
   describe 'ユーザの学習記録' do
     let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') } # 表示される教科名
 
-    # # ログインするユーザとTopページに表示される学習記録
+    # ログインするユーザとTopページに表示される学習記録
     let!(:user) { create(:user, name: 'テスト太郎') } # ログインするユーザ
     let!(:study_record) {
       create(:study_record, user: user, subject: subject, study_date: Time.new(2023, 1, 16), study_time: 120)
     }
 
-    # 他ユーザの学習記録。ログインしているユーザ以外の学習記録はユーザTopページに表示されないことを確認する用
+    # 他ユーザの学習記録。ログインしているユーザ以外の学習記録は、ユーザTopページに表示されないことを確認する為
     let!(:another_user) { create(:user, name: '他人太郎') }
     let!(:another_study_record) {
       create(:study_record, user: another_user, subject: subject, study_date: Time.new(2023, 1, 11), study_time: 1000)

--- a/spec/system/tops_spec.rb
+++ b/spec/system/tops_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'tops_path', type: :system, js: true do
   describe 'ユーザTopページ' do
-    
+
     context "ログインしている場合" do
       let!(:user) { create(:user) }
 
@@ -11,7 +11,7 @@ RSpec.describe 'tops_path', type: :system, js: true do
         # ログインフォームよりログイン
         log_in_with(user)
       end
-    
+
       it '教科マスタを登録するリンクが表示され、リンクから登録ページに正常に遷移できること' do
         expect(page).to have_link '教科を新しく登録する', href: new_subject_path
 
@@ -33,39 +33,40 @@ RSpec.describe 'tops_path', type: :system, js: true do
     end
   end
 
-  # TODO: [CG-42]で対応。機能実装後にコメントアウトを外します
-  # describe 'ユーザの学習記録' do
-  #   let!(:user) { create(:user, name: 'テスト太郎') }
-  #   let!(:study_record) {
-  #     create(
-  #       :study_record, user: user, study_date: Time.current, study_time: Time.new(2023, 1, 4, 2, 30, 0), subject: subject
-  #     )
-  #   }
-  #   let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') }
-  #
-  #   let(:another_study_record) {
-  #     create(:study_record, user: create(:user, name: '他人太郎'),
-  #       study_date: Time.current, study_time: Time.new(2023, 1, 1, 1, 30, 0), subject: subject)
-  #   }
-  #
-  #   it 'ユーザに紐づく学習記録が表示されていること' do
-  #     # ログイン処理をここに書く
-  #     visit tops_path
-  #     expect(page).to have_current_path tops_path
-  #
-  #     expect(page).to have_content 'テスト太郎' # ユーザ名
-  #     expect(page).to have_content 'コラボレイティブ開発特論' # 教科名
-  #     expect(page).to have_content '2023-01-04' # 記録日
-  #     expect(page).to have_content '2:30' # 学習時間
-  #   end
-  #
-  #   it '他ユーザの学習記録は表示されないこと' do
-  #     visit tops_path
-  #     expect(page).to have_current_path tops_path
-  #
-  #     # 他ユーザの学習記録
-  #     expect(page).to_not have_content '2023-01-01'
-  #     expect(page).to_not have_content '1:30'
-  #   end
-  # end
+  describe 'ユーザの学習記録' do
+    let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') } # 表示される教科名
+
+    # # ログインするユーザとTopページに表示される学習記録
+    let!(:user) { create(:user, name: 'テスト太郎') } # ログインするユーザ
+    let!(:study_record) {
+      create(:study_record, user: user, subject: subject, study_date: Time.new(2023, 1, 16), study_time: 120)
+    }
+
+    # 他ユーザの学習記録。ログインしているユーザ以外の学習記録はユーザTopページに表示されないことを確認する用
+    let!(:another_user) { create(:user, name: '他人太郎') }
+    let!(:another_study_record) {
+      create(:study_record, user: another_user, subject: subject, study_date: Time.new(2023, 1, 11), study_time: 1000)
+    }
+
+    before do
+      log_in_with(user)
+    end
+
+    it 'ユーザに紐づく学習記録がTopページに表示されていること' do
+      expect(page).to have_current_path tops_path
+
+      expect(page).to have_content 'テスト太郎' # ユーザ名
+      expect(page).to have_content 'コラボレイティブ開発特論' # 教科名
+      expect(page).to have_content '2023-01-16' # 記録日
+      expect(page).to have_content '120' # 学習時間
+    end
+
+    it '他ユーザの学習記録は表示されないこと' do
+      expect(page).to have_current_path tops_path
+
+      # 他ユーザの学習記録
+      expect(page).to_not have_content '2023-01-11'
+      expect(page).to_not have_content 1000
+    end
+  end
 end


### PR DESCRIPTION
## JIRAへのリンク
CG-42 ユーザトップページに勉強時間を表示する処理の追加

## 概要
ユーザトップページに表示される学習記録を、これまでデモ用にランダムな値を表示させていましたが  
ログインユーザの学習記録が表示されるように修正しました。

## 実装内容
- [x] ログインユーザの学習記録をユーザトップページに表示
- [x] ユーザTOPページをログイン必須画面にしました

## テスト  
- [x] 実装内容を確認するテストを追加修正

## 備考
