### PR TITLE
Feature/cg 44/edit subject master in japanese

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,8 +12,8 @@
             Subjects
           </a>
           <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <li><%= link_to 'index', subjects_path, class: 'dropdown-item' %></li>
-            <li><%= link_to 'new', new_subject_path, class: 'dropdown-item' %></li>
+            <li><%= link_to '科目一覧', subjects_path, class: 'dropdown-item' %></li>
+            <li><%= link_to '科目を追加', new_subject_path, class: 'dropdown-item' %></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="#">Example</a></li>
           </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
           </a>
           <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
             <li><%= link_to '科目一覧', subjects_path, class: 'dropdown-item' %></li>
-            <li><%= link_to '科目を追加', new_subject_path, class: 'dropdown-item' %></li>
+            <li><%= link_to '科目を追加する', new_subject_path, class: 'dropdown-item' %></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="#">Example</a></li>
           </ul>

--- a/app/views/subjects/_form.html.erb
+++ b/app/views/subjects/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @subject) do |form| %>
   <%= render 'shared/error_messages', object: @subject %>
 
-    <%= form.label :name %>
+    <%= form.label :科目名 %>
     <%= form.text_field :name, class: 'form-control' %>
     <br>
     <%= form.submit "新規登録", class: "btn btn-primary" %>

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id subject %>">
   <p>
-    <strong>Subject:</strong>
+    <strong>科目名:</strong>
     <%= subject.name %>
   </p>
 

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -1,6 +1,5 @@
 <div id="<%= dom_id subject %>">
   <p>
-    <strong>科目名:</strong>
     <%= subject.name %>
   </p>
 

--- a/app/views/subjects/index.html.erb
+++ b/app/views/subjects/index.html.erb
@@ -1,6 +1,6 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Subjects</h1>
+<h1>科目一覧</h1>
 
 <div id="subjects">
   <% @subjects.each do |subject| %>

--- a/app/views/subjects/new.html.erb
+++ b/app/views/subjects/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New subject</h1>
+<h1>科目を追加する</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">

--- a/spec/system/tops_spec.rb
+++ b/spec/system/tops_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'tops_path', type: :system, js: true do
       click_link  '教科を新しく登録する'
 
       expect(page).to have_current_path new_subject_path
-      expect(page).to have_content 'New subject'
+      expect(page).to have_content '科目を追加する'
     end
 
     it '今日の学習を記録するリンクが表示され、リンクから学習記録ページに正常に遷移できること' do


### PR DESCRIPTION
## JIRAへのリンク
CG-44 (教科マスタの表記を日本語に直す)

## 概要
- 英語になっている表記を日本語へ修正

## 実装内容
- Newを「科目を追加する」に統一
- Subjectsを「科目一覧」に統一
- ヘッダーの修正に合わせてテストコードを修正
- 科目名の前の接頭語は削除

## テスト  
- 別課題でやります

## 備考
