### PR TITLE
CG-57 フッターの修正

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,7 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+
+.page-contents {
+  min-height: 87vh;
+  padding-bottom: 20px;
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="text-center text-lg-start bg-light text-muted position-absolute bottom-0 w-100">
+<footer class="text-center text-lg-start bg-light text-muted w-100">
   <div class="text-center p-4">
     © <%= Time.current.year %> Copyright:
     <%= link_to ApplicationHelper::APPLICATION_NAME, tops_path, class: "text-reset fw-bold"  %>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,21 +1,19 @@
 <div class="row">
   <div class="col-sm-3 d-inline-flex">
     <div class="card border border-2" style="padding: 20px">
-      <%= image_tag 'sample_user.png', class: 'h-100' %>
+      <%= image_tag 'sample_user.png' %>
     </div>
   </div>
-  <div class="col-sm-5 d-inline-flex">
+  <div class="col-sm-5 d-inline-flex card-group">
     <div class="card">
       <div class="card-header">
         <%= current_user.name %>
       </div>
       <div class="card-body">
         <blockquote class="blockquote mb-0">
-          <p>ここにテキスト ここにテキスト ここにテキスト ここに</p>
-          <p>ここにテキスト ここにテキスト ここにテキスト ここに</p>
-          <p>ここにテキスト ここにテキスト ここにテキスト ここに</p>
-          <p>ここにテキスト ここにテキスト ここにテキスト ここに</p>
-          <p>ここにテキスト ここにテキスト ここにテキスト ここに</p>
+          <span>
+            ここにテキスト ここにテキスト ここにテキスト ここにテキスト
+          </span>
         </blockquote>
       </div>
     </div>


### PR DESCRIPTION
## JIRAへのリンク
CG-57 フッターの修正

## 概要  
### 現象
画面サイズを小さくしたり、ブラウザでページを拡大すると  
ボタン等ページ下のコンテンツがフッターに隠れてしまう  

### 原因  
フッターの位置を `position-absolute bottom-0` にて絶対位置で指定していたため  
画面サイズを小さくしたり、ブラウザでページを拡大すると位置が変わらないフッターの下に  
他のコンテンツが隠れてしまっていた  
  
### 修正  
絶対位置での指定をやめ、ページコンテンツが表示される部分の高さをある程度確保し、  
ページを拡大しても(エラーが表示されたときも)  フッターに隠れないように修正した

## 実装内容
- [x] ページ下部のボタン等がフッターに隠れないように修正  
- [x] 画面サイズによって不自然に縦長になるページ上部のコンテンツをついでに少し調整した

## テスト  
- [x] 目視  
(developブランチで再現させて、`feature/CG-57/fix_footer_style` ブランチにcheckoutして解消されていることを確認)

## 備考
(画像)  
  
※ ページをブラウザで150%くらいに拡大してフォームでエラーを出すと  
フッターで隠れるボタンの状態が再現します

| before | after |  
| :-: | :-: |  
| <img width="600" alt="ss_21" src="https://user-images.githubusercontent.com/16791696/213713956-15c00680-2742-479a-956a-b5288e973c22.png"> |  <img width="600" alt="ss_22" src="https://user-images.githubusercontent.com/16791696/213713973-84668c92-e83f-4a75-be12-8491cde0a6ae.png"> |




