### PR TITLE
勉強時間登録をログインユーザーに紐づけ

### DIFF
--- a/app/controllers/study_records_controller.rb
+++ b/app/controllers/study_records_controller.rb
@@ -6,8 +6,8 @@ class StudyRecordsController < ApplicationController
     end
 
     def create
+        @study_record = current_user.study_records.build(study_recored_params)
 
-        @study_record = StudyRecord.new(study_recored_params)
         if @study_record.save
             redirect_to tops_path
         else

--- a/app/views/study_records/_form.html.erb
+++ b/app/views/study_records/_form.html.erb
@@ -1,9 +1,6 @@
 <%= form_with(model: @study_record) do |form| %>
   <%= render 'shared/error_messages', object: @study_record %>
 
-    <%= form.label :user_id %>
-    <%= form.collection_select :user_id, User.all, :id, :name, {prompt: ""}, {class: "form-control input-sm"} %>
-
     <%= form.label :subject_id %>
     <%= form.collection_select :subject_id, Subject.all, :id, :name, {prompt: ""}, {class: "form-control input-sm"} %>
 

--- a/spec/requests/study_recored_spec.rb
+++ b/spec/requests/study_recored_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StudyRecordsController, type: :request do
     describe 'GET #new' do
       context "ログインしていない場合" do
         before do
+          # TODO テストするべきパスが異なる (CG-56：ログインしていないときのルーティング制限で修正予定)
           get tops_path
         end
 
@@ -20,48 +21,53 @@ RSpec.describe StudyRecordsController, type: :request do
       end
     end
       
-    #   context "ログインしている場合" do
-    #     let!(:user) { create(:user) }
-    #     before do
-    #       log_in(user)
-    #       get tops_path
-    #     end
+      context "ログインしている場合" do
+        let!(:user) { create(:user) }
+        before do
+          log_in(user)
+          get new_study_record_path
+        end
       
-    #     it 'ステータス200が返ること' do
-    #       expect(response.status).to eq 200
-    #     end
+        it 'ステータス200が返ること' do
+          expect(response.status).to eq 200
+        end
     
-    #     it '勉強登録ページが表示されること' do
-    #       expect(response.body).to include '勉強時間を記録'
-    #       expect(response.body).to include '新規登録'
-    #     end
+        it '勉強登録ページが表示されること' do
+          expect(response.body).to include '勉強時間を記録'
+          expect(response.body).to include '新規登録'
+        end
 
-    # end
+    end
 
-    # describe "POST #create" do
-    #   context "正常に登録が完了した時" do
-    #     it "ステータス302が返ること" do
-    #       @user = create(:user, name: 'test', email: "test@example.com", password: '123456')
-    #       @subject = create(:subject, name: 'test')
-    #       post study_records_path params: {
-    #           study_record: { user_id: @user.id, subject_id: @subject.id, study_date: "2023/01/01", study_time: "01:01"  }
-    #         }
-    #       expect(response.status).to eq 302
-    #     end
-    #   end
+    describe "POST #create" do
+      let!(:user) { create(:user) }
+      before do
+        log_in(user)
+      end
 
-    #   context "登録項目に不備がある場合" do
-    #     it "ステータス422が返ること" do
-    #         post study_records_path params: {
-    #             study_record: { user_id: nil, subject_id: nil, study_date: "2023/01/01", study_time: "00:00" }
-    #         }
-    #         expect(response.status).to eq 422
-    #         expect(response.body).to include 'The form contains 3 errors.'
-    #         expect(response.body).to include 'User must exist'
-    #         expect(response.body).to include 'Subject must exist'
-    #         expect(response.body).to include 'Study time must be greater than 0'
-    #     end
-    #   end
-    # end
+      context "正常に登録が完了した時" do
+        it "ステータス302が返ること" do
+          # ユーザー情報はセッションから取得するのでここでは紐付ける教科のみ作成
+          @subject = create(:subject, name: 'test')
+          post study_records_path params: {
+              study_record: {subject_id: @subject.id, study_date: "2023/01/01", study_time: "01:01"  }
+            }
+          expect(response.status).to eq 302
+        end
+      end
+
+      context "登録項目に不備がある場合" do
+        it "ステータス422が返ること" do
+            post study_records_path params: {
+                study_record: {subject_id: nil, study_date: "2023/01/01", study_time: "00:00" }
+            }
+            expect(response.status).to eq 422
+            expect(response.body).to include 'The form contains 2 errors.'
+            expect(response.body).to include 'Subject must exist'
+            expect(response.body).to include 'Study time must be greater than 0'
+        end
+        
+      end
+    end
 
 end


### PR DESCRIPTION
## JIRAへのリンク
CG-55 (勉強時間登録時に現在のユーザーで固定する)

## 概要
勉強時間の登録時のユーザーをドロップダウンで選択ではなく、ログインユーザーに固定

## 実装内容
- [x] study_controller内でカレントユーザーでstudy_recordを作るように変更

## テスト  
- [x] ログインユーザーで勉強時間が登録できることを確認 (CG-53)

## 備考
