### PR TITLE
セッションをみてページ遷移の挙動を修正

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,10 @@
 class StaticPagesController < ApplicationController
+  include SessionsHelper
+
   def home
+    if logged_in?
+      redirect_to tops_path
+    end
   end
+
 end

--- a/app/controllers/study_records_controller.rb
+++ b/app/controllers/study_records_controller.rb
@@ -1,5 +1,5 @@
 class StudyRecordsController < ApplicationController
-    before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
+    before_action :logged_in_user, only: [:new, :create]
     
     def new
         @study_record = StudyRecord.new

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -1,6 +1,6 @@
 class SubjectsController < ApplicationController
   before_action :set_subject, only: %i[ show edit update destroy ]
-  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
+  before_action :logged_in_user, only: [:index, :new, :edit, :update, :destroy]
 
   # GET /subjects
   def index

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,10 +1,13 @@
-<h1>StudyRecords Topページ</h1>
+<h1>StudyRecords</h1>
 <% flash.each do |message_type, message| %>
     <div class="alert alert-<%= message_type %>"><%= message %></div>
 <% end %>
-<%=link_to(new_user_path) do %>
- <button class="btn btn-secondary btn-lg" >ユーザー登録</button>
-<%end%>
-<%=link_to(login_path) do %>
- <button class="btn btn-secondary btn-lg" >ログインページ</button>
+
+<% if not logged_in? %>
+    <%=link_to(new_user_path) do %>
+        <button class="btn btn-secondary btn-lg" >ユーザー登録</button>
+    <%end%>
+    <%=link_to(login_path) do %>
+        <button class="btn btn-secondary btn-lg" >ログインページ</button>
+    <%end%>
 <%end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   
   root 'static_pages#home'
   resources :tops, only: :index
-  resources :users
+  resources :users, only: [:new, :create, :show]
   resources :subjects, only: [:index, :new, :create, :show]
-  resources :study_records
+  resources :study_records, only: [:new, :create]
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/spec/requests/study_recored_spec.rb
+++ b/spec/requests/study_recored_spec.rb
@@ -4,18 +4,15 @@ RSpec.describe StudyRecordsController, type: :request do
     describe 'GET #new' do
       context "ログインしていない場合" do
         before do
-          # TODO テストするべきパスが異なる (CG-56：ログインしていないときのルーティング制限で修正予定)
-          get tops_path
+          get new_study_record_path
         end
 
         it 'ステータス302が返ること' do
           expect(response.status).to eq 302
         end
 
-        it 'ルートにリダイレクトされログインして下さいのメッセージが表示されること' do
+        it 'ルートにリダイレクトされること' do
           expect(response).to redirect_to('/')
-          # TODO できればリダイレクト先のbodyがみたい
-          # expect(response.body).to include 'ログインして下さい'
         end
 
       end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -4,21 +4,32 @@ RSpec.describe 'root_path', type: :system, js: true do
   describe 'StudyRecords Topページ' do
     let!(:user) { create(:user) }
 
-    it 'ログインページより正常にログインできること' do
-      visit root_path
+    context "ログインしていない場合" do
 
-      # ログイン前ページ
-      expect(page).to have_content 'StudyRecords Topページ'
-      expect(page).to have_button 'ユーザー登録'
-      expect(page).to have_button 'ログインページ'
+      it 'ログインページより正常にログインできること' do
+        visit root_path
 
-      # ログインフォームよりログイン
-      log_in_with(user)
+        # ログイン前ページ
+        expect(page).to have_content 'StudyRecords'
+        expect(page).to have_button 'ユーザー登録'
+        expect(page).to have_button 'ログインページ'
 
-      # ログイン後ページ
-      expect(page).to have_content 'StudyRecords'
-      expect(page).to have_current_path tops_path
-      expect(page).to have_content user.name
+        # ログインフォームよりログイン
+        log_in_with(user)
+
+        # ログイン後ページ
+        expect(page).to have_content 'StudyRecords'
+        expect(page).to have_current_path tops_path
+        expect(page).to have_content user.name
+      end
     end
+
+    # context "ログインしている場合" do
+    #   it 'topsページにリダイレクトされること' do
+    #     # TODO
+    #     # リダイレクトの検証方法が分からない
+    #   end
+    # end
+
   end
 end


### PR DESCRIPTION
## JIRAへのリンク
CG-56 (ログインしていないときのルーティング制限)
CG-47 (study_recordのルーティング制限)も修正

## 概要
ログインしていないときにページにアクセスできないように修正

## 実装内容
- [x] ログインしていないとき`/study_records`にアクセスできないように変更
- [x] ログインしていないとき`/subjects`にアクセスできないように変更
- [x] ログインしていないとき`study_records`にアクセスできないか確認するrpsecを修正
- [x] ログインしているときに`root`にアクセスしたとき`/tops`ページに遷移するように修正（ログインユーザーがログイン/ユーザー登録ボタンの再度押下防止）

## テスト  
- [x] rspceでログインしてないときstudy_recordsにアクセスするとルートにリダイレクトする


## 備考
- subjectのテストは未実装
- `spec/system/static_pages_spec.rb`でログイン時に`root`にアクセスしたら`tops`にリダイレクトする検証は書き方が分からず書けず