### PR TITLE
CG-49 (教科マスタのテストの追加)

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -26,7 +26,7 @@ class SubjectsController < ApplicationController
     @subject = Subject.new(subject_params)
 
     if @subject.save
-      redirect_to @subject, notice: "Subject was successfully created."
+      redirect_to @subject, notice: "科目が追加されました"
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -3,6 +3,6 @@
 <%= render @subject %>
 
 <div>
-  <%= link_to "Back to subjects", subjects_path %>
+  <%= link_to "科目一覧に戻る", subjects_path %>
 
 </div>

--- a/spec/models/subjects_spec.rb
+++ b/spec/models/subjects_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Subject, type: :model do
+end

--- a/spec/requests/subjects_controller_spec.rb
+++ b/spec/requests/subjects_controller_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe SubjectsController, type: :request do
             end
         end
 
-        # context "登録に異常があった場合" do
-        #     it "ステータス422が返ること" do
+        context "登録に異常があった場合" do
+            it "ステータス422が返ること" do
         #         post subjects_path params: { subject: { name: 'コラボレイティブ開発特論' } }
         #         expect(response.status).to eq 422
         #         expect(response.body).to include 'The form contains 1 error.'
-        #     end
-        # end
+            end
+        end
     end
 
     #科目登録後 

--- a/spec/requests/subjects_controller_spec.rb
+++ b/spec/requests/subjects_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe SubjectsController, type: :request do
+    
+    #科目登録画面
+    describe 'GET #new' do
+        context "ログインしていない場合" do
+            before do
+                get tops_path
+            end
+
+            it 'ステータス302が返ること' do
+                expect(response.status).to eq 302
+            end
+        end
+        context "ログインしている場合" do
+            #ログイン状態用のユーザー
+            let!(:user) { create(:user) }
+            before do
+                log_in(user)
+                get new_subject_path
+            end
+
+            it 'ステータス200が返ること' do
+                expect(response.status).to eq 200
+            end
+        end
+    end
+
+    #科目一覧
+    describe 'GET #index' do
+        context "ログインしていない場合" do
+            before do
+                get tops_path
+            end
+
+            it 'ステータス302が返ること' do
+                expect(response.status).to eq 302
+            end
+        end
+        context "ログインしている場合" do
+            let!(:user) { create(:user) }
+            before do
+              log_in(user)
+              get subjects_path
+            end
+
+            it 'ステータス200が返ること' do
+                expect(response.status).to eq 200
+            end
+        end
+    end
+
+    #科目登録時
+    describe "POST #create" do
+        let!(:user) { create(:user) }
+        before do
+          log_in(user)
+          get new_subject_path
+        end
+
+        context "正常に登録できた場合" do
+            it "ステータス302が返ること" do
+                post subjects_path params: { subject: { name: 'テスト' } }
+                expect(response.status).to eq 302
+            end
+        end
+
+        # context "登録に異常があった場合" do
+        #     it "ステータス422が返ること" do
+        #         post subjects_path params: { subject: { name: 'コラボレイティブ開発特論' } }
+        #         expect(response.status).to eq 422
+        #         expect(response.body).to include 'The form contains 1 error.'
+        #     end
+        # end
+    end
+
+    #科目登録後 
+
+end

--- a/spec/requests/subjects_controller_spec.rb
+++ b/spec/requests/subjects_controller_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe SubjectsController, type: :request do
     #科目登録時
     describe "POST #create" do
         let!(:user) { create(:user) }
+        #テストデータ
+        let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') }
         before do
           log_in(user)
           get new_subject_path
@@ -68,9 +70,9 @@ RSpec.describe SubjectsController, type: :request do
 
         context "登録に異常があった場合" do
             it "ステータス422が返ること" do
-        #         post subjects_path params: { subject: { name: 'コラボレイティブ開発特論' } }
-        #         expect(response.status).to eq 422
-        #         expect(response.body).to include 'The form contains 1 error.'
+                post subjects_path params: { subject: { name: 'コラボレイティブ開発特論' } }
+                expect(response.status).to eq 422
+                expect(response.body).to include 'The form contains 1 error.'
             end
         end
     end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -7,5 +7,6 @@ module SystemSpecHelpers
     fill_in 'Password', with: user.password
 
     click_on 'ログイン'
+    expect(page).to have_current_path tops_path
   end
 end

--- a/spec/system/subjects_spec.rb
+++ b/spec/system/subjects_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'subjects_path', type: :system, js: true do
+RSpec.describe 'Subjects', type: :system, js: true do
   describe '科目一覧ページ' do
     let!(:user) { create(:user) }
     #表示用のテストデータ
@@ -15,7 +15,7 @@ RSpec.describe 'subjects_path', type: :system, js: true do
       it '科目一覧が表示され、科目を追加するページに正常に遷移できること' do
         visit subjects_path
         expect(page).to have_current_path subjects_path
-        #expect(page).to have_content 'コラボレイティブ開発特論'
+        expect(page).to have_content 'コラボレイティブ開発特論'
         expect(page).to have_link href: new_subject_path
         click_on '科目を追加する'
       end

--- a/spec/system/subjects_spec.rb
+++ b/spec/system/subjects_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'subjects_path', type: :system, js: true do
+  describe '科目一覧ページ' do
+    let!(:user) { create(:user) }
+    #表示用のテストデータ
+    let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') }
+    
+    context "ログインしている場合" do
+      before do
+        # ログインフォームよりログイン
+        log_in_with(user)
+      end
+
+      it '科目一覧が表示され、科目を追加するページに正常に遷移できること' do
+        visit subjects_path
+        expect(page).to have_current_path subjects_path
+        #expect(page).to have_content 'コラボレイティブ開発特論'
+        expect(page).to have_link href: new_subject_path
+        click_on '科目を追加する'
+      end
+    end
+  end
+
+  describe '科目登録ページ' do
+    let!(:user) { create(:user) }
+
+    context "ログインしている場合" do
+      before do
+        # ログインフォームよりログイン
+        log_in_with(user)
+      end
+
+      it '科目登録ページに科目名が表示され、新規登録ページと科目一覧ページに正常に遷移できること' do
+        visit new_subject_path
+        expect(page).to have_current_path new_subject_path
+        expect(page).to have_content '科目名'
+        expect(page).to have_link href: subjects_path
+        click_on '科目一覧に戻る'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## JIRAへのリンク
CG-49 (教科マスタのテストの追加)

## 概要
教科マスタのテストコードの記載

## 実装内容（テスト）
- [x] ＜controller＞科目登録画面のステータスの確認
- [x]   ＜controller＞科目一覧画面のステータスの確認
- [x] ＜controller＞科目登録時の正常系、異常系ステータスの確認
- [x] ＜system＞科目一覧ページの表示とページ遷移の確認
- [x]  ＜system＞科目登録ページの表示とページ遷移の確認

## 備考
科目登録後の#showのページのテストがうまく書けていません
