### PR TITLE
CG-59 勉強時間を削除できるボタンをユーザTOPページに追加する

### DIFF
--- a/app/controllers/study_records_controller.rb
+++ b/app/controllers/study_records_controller.rb
@@ -1,6 +1,7 @@
 class StudyRecordsController < ApplicationController
-    before_action :logged_in_user, only: [:new, :create]
-    
+    before_action :logged_in_user, only: [:new, :create, :destroy]
+    before_action :set_study_record, only: [:destroy]
+
     def new
         @study_record = StudyRecord.new
     end
@@ -15,6 +16,17 @@ class StudyRecordsController < ApplicationController
         end
     end
 
+    def destroy
+        if @study_record
+            @study_record.destroy
+            flash[:success] = "学習記録を削除しました。"
+        else
+            flash[:warning] = "削除時にエラーが発生しました"
+        end
+
+        redirect_to tops_path, status: :see_other
+    end
+
     private
         def study_recored_params
             params[:study_record][:study_time] = convert_time_field_to_minutes(params[:study_record][:study_time])
@@ -25,5 +37,9 @@ class StudyRecordsController < ApplicationController
             if string.kind_of?(String)
               string.split(":").map(&:to_i).then { |hour, minutes| hour * 60 + minutes }
             end
+        end
+
+        def set_study_record
+            @study_record = current_user.study_records.find_by(id: params[:id])
         end
 end

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,3 +1,6 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>
 <div class="row">
   <div class="col-sm-3 d-inline-flex">
     <div class="card border border-2" style="padding: 20px">
@@ -34,6 +37,7 @@
           <th scope="col">日付</th>
           <th scope="col">科目</th>
           <th scope="col">勉強時間(minutes)</th>
+          <th scope="col">操作</th>
         </tr>
         </thead>
         <tbody>
@@ -43,6 +47,17 @@
             <td><%= study_record.study_date.strftime("%F") %></td>
             <td><%= study_record.subject.name%></td>
             <td><%= study_record.study_time %></td>
+            <td>
+              <%= button_to '削除', study_record,
+                class: 'btn btn-sm btn-danger',
+                method: :delete,
+                form: {
+                  data: {
+                    turbo_confirm: "日付: #{study_record.study_date.strftime('%F')}\n教科名: #{study_record.subject.name}\n勉強時間: #{study_record.study_time} 分\nを本当に削除してよろしいですか?"
+                  }
+                }
+              %>
+          </td>
           </tr>
         <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resources :tops, only: :index
   resources :users, only: [:new, :create, :show]
   resources :subjects, only: [:index, :new, :create, :show]
-  resources :study_records, only: [:new, :create]
+  resources :study_records, only: [:new, :create, :destroy]
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/spec/requests/study_recored_spec.rb
+++ b/spec/requests/study_recored_spec.rb
@@ -67,4 +67,39 @@ RSpec.describe StudyRecordsController, type: :request do
       end
     end
 
+    describe 'POST #destroy' do
+      let!(:user) { create(:user) }
+      let!(:study_record) { create(:study_record, user: user) }
+
+      before do
+        log_in(user)
+      end
+
+      context '正常系' do
+        it '学習記録が削除される' do
+          delete study_record_path(study_record)
+
+          expect(flash).to be_any
+          expect(flash[:success]).to eq "学習記録を削除しました。"
+          expect(response.status).to eq 303
+          expect(response).to redirect_to('/tops')
+
+          # レコードが削除される
+          expect(StudyRecord.find_by(id: study_record.id)).to eq nil
+        end
+      end
+
+      context '異常系(不正なパラメータ)' do
+        it 'エラーが発生した旨のメッセージが返る' do
+          delete study_record_path(-1) # 不正なパラメータ
+
+          expect(flash).to be_any
+          expect(flash[:warning]).to eq "削除時にエラーが発生しました"
+          expect(response.status).to eq 303
+          expect(response).to redirect_to('/tops')
+
+          expect(StudyRecord.find_by(id: study_record.id)).to eq study_record
+        end
+      end
+    end
 end

--- a/spec/system/tops_spec.rb
+++ b/spec/system/tops_spec.rb
@@ -69,4 +69,29 @@ RSpec.describe 'tops_path', type: :system, js: true do
       expect(page).to_not have_content 1000
     end
   end
+
+  describe '学習記録の削除' do
+    let!(:subject) { create(:subject, name: 'コラボレイティブ開発特論') }
+    let!(:user) { create(:user) }
+    let!(:study_record) {
+      create(:study_record, user: user, subject: subject)
+    }
+
+    before do
+      log_in_with(user)
+    end
+
+    it '削除ボタンで学習記録を削除することができる' do
+      expect(page).to have_current_path tops_path
+
+      expect(page).to have_content 'コラボレイティブ開発特論'
+      click_on '削除'
+
+      # JavaScriptのalertで表示される確認ダイアログ。accept_confirmでOKをクリックする
+      expect(page.accept_confirm).to include '本当に削除してよろしいですか?'
+      expect(page).to have_content '学習記録を削除しました。'
+
+      expect(page).to_not have_content 'コラボレイティブ開発特論'
+    end
+  end
 end


### PR DESCRIPTION
## JIRAへのリンク
CG-59 勉強時間を削除できるボタンをユーザTOPページに追加する

## 概要
勉強時間を削除できるボタンをユーザTOPページ、勉強時間の右側に追加しました

## 実装内容
- [x] 勉強時間削除ボタンの実装、クリック時に確認ダイアログを表示

## テスト  
- [x] 実装内容を確認するテストを追加
- [x] 既存のテストがパスすること

## 備考
| クリック時 | 削除時 |
| :-: | :-: |
| <img width="600" alt="ss 2" src="https://user-images.githubusercontent.com/16791696/214385504-ae03f45d-37c2-4da2-aab6-3bc859c8a859.png"> | <img width="600" alt="ss 3" src="https://user-images.githubusercontent.com/16791696/214385629-d83bea3c-982e-413f-a1aa-111d9f56119a.png"> |
